### PR TITLE
[DOPS-1363] Create CI for pswap-token-whitelist

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,9 @@
-@Library('jenkins-library') _
+@Library('jenkins-library@feature/submodule-for-js')
 
 def pipeline = new org.js.LibPipeline(
     steps: this,
     test: false,
+    buildDir = './polkaswap-token-whitelist-js',
     dockerImageName: 'soramitsu/polkaswap-token-whitelist-js-library',
     buildDockerImage: 'build-tools/node:14-ubuntu',
     buildCmds: ['yarn', 'NODE_ENV=production yarn build'],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,15 +1,12 @@
-@Library('jenkins-library@feature/submodule-for-js')
+@Library('jenkins-library')
 
 def pipeline = new org.js.LibPipeline(
     steps: this,
     test: false,
     buildDir: './polkaswap-token-whitelist-js',
-    dockerImageName: 'soramitsu/polkaswap-token-whitelist-js-library',
     buildDockerImage: 'build-tools/node:14-ubuntu',
     buildCmds: ['yarn', 'NODE_ENV=production yarn build'],
-    pushCmds: ['npm publish'],
     npmRegistries: ['': 'npm-soramitsu-admin'],
     npmLoginEmail:'admin@soramitsu.co.jp',
-    gitUpdateSubmodule: true,
-    libPushBranches: ['PR-3'])
+    gitUpdateSubmodule: true)
 pipeline.runPipeline()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,11 +3,13 @@
 def pipeline = new org.js.LibPipeline(
     steps: this,
     test: false,
-    buildDir = './polkaswap-token-whitelist-js',
+    buildDir: './polkaswap-token-whitelist-js',
     dockerImageName: 'soramitsu/polkaswap-token-whitelist-js-library',
     buildDockerImage: 'build-tools/node:14-ubuntu',
     buildCmds: ['yarn', 'NODE_ENV=production yarn build'],
     pushCmds: ['npm publish'],
     npmRegistries: ['': 'npm-soramitsu-admin'],
-    npmLoginEmail:'admin@soramitsu.co.jp')
+    npmLoginEmail:'admin@soramitsu.co.jp',
+    gitUpdateSubmodule: true,
+    libPushBranches: ['PR-3'])
 pipeline.runPipeline()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,12 @@
+@Library('jenkins-library') _
+
+def pipeline = new org.js.LibPipeline(
+    steps: this,
+    test: false,
+    dockerImageName: 'soramitsu/polkaswap-token-whitelist-js-library',
+    buildDockerImage: 'build-tools/node:14-ubuntu',
+    buildCmds: ['yarn', 'NODE_ENV=production yarn build'],
+    pushCmds: ['npm publish'],
+    npmRegistries: ['': 'npm-soramitsu-admin'],
+    npmLoginEmail:'admin@soramitsu.co.jp')
+pipeline.runPipeline()


### PR DESCRIPTION
# Task

[DOPS-1363] Create CI for pswap-token-whitelist.

## Changes

CI configured, Jenkinsfile added:
  1. Gitsubmodule support added.
  2. Build directory var added.

## Tests

The library was built and pushed:
1. [Push test.]
2. [Replay's job before the merge.]

## Author

Signed-off-by: Creed <creed@soramitsu.co.jp>

[DOPS-1363]: https://soramitsu.atlassian.net/browse/DOPS-1363
[Push test.]: https://jenkins.soramitsu.co.jp/job/polkaswap/job/token-whitelist/view/change-requests/job/PR-3/12/
[Replay's job before the merge.]: https://jenkins.soramitsu.co.jp/job/polkaswap/job/token-whitelist/view/change-requests/job/PR-3/14/